### PR TITLE
Implement dual-hook agent architecture (onLabel + postLabel)

### DIFF
--- a/docs/adr/018-dual-hook-agent-architecture.md
+++ b/docs/adr/018-dual-hook-agent-architecture.md
@@ -1,0 +1,298 @@
+# ADR-018: Dual-Hook Agent Architecture
+
+**Status**: Accepted
+**Date**: 2025-10-03
+**Deciders**: Project team
+
+## Context
+
+The original pluggable agent architecture (ADR-004) and self-contained agent pattern (ADR-011) provided a foundation for extending email processing functionality. However, as the system evolved, significant limitations emerged in how agents interacted with the classification pipeline:
+
+**Previous Architecture Limitations:**
+1. **Single Handler Pattern**: Agents registered only one handler function per label
+2. **Classification-Only Execution**: Agents could only act on emails during the classification pipeline
+3. **Manual Label Gap**: Manually-labeled emails (e.g., user applies `reply_needed` label directly) required separate scheduled triggers to be processed
+4. **Trigger Proliferation**: Each action agent potentially needed its own independent trigger (e.g., Reply Drafter had a separate 30-minute trigger)
+5. **No Immediate + Cleanup Pattern**: No clean way to implement "immediate action for auto-classified emails + periodic scan for manual labels"
+
+**Concrete Example - Reply Drafter Pain Points:**
+- Auto-classified emails: Draft created immediately during classification ✅
+- Manually-labeled emails: Required waiting up to 30 minutes for separate trigger 🐌
+- System complexity: Two execution paths (agent handler + independent trigger)
+- Trigger management: Each agent needing scanning behavior required separate trigger setup
+
+**Architectural Tension:**
+The system needed to support two fundamentally different execution patterns:
+1. **Immediate per-email actions**: React to individual emails as they're classified (forward, draft, notify)
+2. **Inbox-wide scanning**: Periodically scan for emails with specific labels, regardless of how they were labeled (catch manual labels, cleanup operations)
+
+The previous single-handler pattern forced agents to choose one or implement complex workarounds with separate triggers.
+
+## Decision
+
+We implemented a **dual-hook agent architecture** that provides two distinct execution points within the same hourly classification run:
+
+### Hook 1: `onLabel` - Immediate Per-Email Actions
+- **When**: Called once per email as the label is applied during classification
+- **Purpose**: Immediate actions on newly-classified emails
+- **Context**: Receives full context about the specific email being labeled
+- **Use Cases**: Draft reply, forward email, send notification, apply additional labels
+- **Execution**: Runs inline during `Organizer.apply_()` for each labeled thread
+
+### Hook 2: `postLabel` - Inbox-Wide Scanning
+- **When**: Called once after all email labeling is complete
+- **Purpose**: Scan entire inbox for emails with specific labels
+- **Context**: No parameters provided - hook scans independently
+- **Use Cases**: Catch manually-labeled emails, cleanup operations, batch processing
+- **Execution**: Runs once via `Agents.runPostLabelHandlers()` after labeling phase
+
+### Registration API
+
+**New Dual-Hook Pattern (BREAKING CHANGE):**
+```javascript
+AGENT_MODULES.push(function(api) {
+  api.register(
+    'label_name',           // Label to trigger on
+    'AgentName',            // Agent name for logging
+    {
+      onLabel: function(ctx) {
+        // Immediate per-email action
+        // ctx: { label, decision, threadId, thread, cfg, dryRun, log() }
+        return { status: 'ok', info: 'processed' };
+      },
+      postLabel: function() {
+        // Inbox-wide scan (no parameters)
+        // Scan for manually-labeled emails
+        const threads = findEmailsByLabelWithAge_('label_name', 1);
+        // Process threads...
+      }
+    },
+    {
+      enabled: true,        // Optional: default true
+      runWhen: 'afterLabel', // Optional: 'afterLabel' | 'always'
+      timeoutMs: 30000      // Optional: soft timeout for monitoring
+    }
+  );
+});
+```
+
+**Requirements:**
+- At least one hook (`onLabel` or `postLabel`) must be provided
+- Both hooks are optional, but at least one must exist
+- Hooks parameter must be an object with `onLabel` and/or `postLabel` properties
+- Each hook must be a function if provided
+
+**Old Single-Handler Pattern (DEPRECATED):**
+```javascript
+// NO LONGER SUPPORTED - WILL THROW ERROR
+api.register('label', 'AgentName', handlerFunction, options);
+```
+
+### Execution Flow
+
+```
+Hourly Trigger Fires
+  └─> findUnprocessed_() identifies unlabeled threads
+  └─> categorizeWithGemini_() classifies emails
+  └─> Organizer.apply_() processes results
+       ├─> For each thread:
+       │    ├─> Apply label
+       │    └─> Call onLabel hooks (immediate per-email actions)
+       │
+       └─> After all labeling complete:
+            └─> Call postLabel hooks (inbox-wide scans)
+```
+
+### Idempotency Strategy
+
+Both hooks leverage label-based idempotency (ADR-016):
+- **onLabel**: Processes emails as they receive labels during classification
+- **postLabel**: Scans for emails with labels, uses application-level checks to prevent duplicate processing
+- **Example**: Reply Drafter checks for existing drafts before creating new ones
+- **Result**: Same email may be seen by both hooks, but idempotency prevents duplicate actions
+
+## Alternatives Considered
+
+### Alternative 1: Keep Separate Triggers Per Agent
+- **Pros**: Simple to understand, each agent fully independent, flexible scheduling
+- **Cons**: Trigger proliferation (4+ triggers), harder to manage, separate execution contexts, quota fragmentation
+- **Why not chosen**: Violated simplicity principle and made system harder to maintain
+
+### Alternative 2: Single Hook with Mode Parameter
+```javascript
+api.register('label', 'Agent', handler, { mode: 'immediate' | 'scan' | 'both' });
+```
+- **Pros**: Single registration call, simpler API surface
+- **Cons**: Forces handlers to implement branching logic, less clear separation of concerns, single function handles two distinct use cases
+- **Why not chosen**: Violates single responsibility principle and makes handlers more complex
+
+### Alternative 3: Separate Agent Types (ImmediateAgent vs. ScanAgent)
+- **Pros**: Clear type distinction, enforces pattern adherence
+- **Cons**: Requires duplicate registration for agents needing both behaviors, more complex agent framework
+- **Why not chosen**: Creates unnecessary complexity for the common "immediate + scan" use case
+
+### Alternative 4: Event Queue with Workers
+- **Pros**: Highly scalable, retry logic built-in, fault-tolerant
+- **Cons**: Requires external infrastructure, overengineered for Apps Script, contradicts serverless architecture
+- **Why not chosen**: Too complex for the Apps Script environment and current scale
+
+### Alternative 5: onLabel + Scheduled Batch (Status Quo)
+- **Pros**: Already implemented, agents can use independent scheduling
+- **Cons**: Trigger proliferation, separate execution contexts, manual labels have delay, complex debugging
+- **Why not chosen**: This is the problem we're solving - architectural limitations led to this decision
+
+## Consequences
+
+### Positive
+- **Zero Trigger Proliferation**: All agents run in single hourly trigger, no need for separate scheduled triggers
+- **Immediate Action**: Auto-classified emails get instant processing via `onLabel`
+- **Manual Label Coverage**: `postLabel` catches manually-labeled emails within the hour
+- **Clean Separation**: Immediate vs. scanning logic separated into distinct hooks
+- **Simpler Agent Development**: Clear pattern for "immediate + cleanup" behavior
+- **Unified Execution Context**: Both hooks run in same execution, share budget and configuration
+- **Better Debugging**: Single execution log contains all agent activity
+- **Consistent Timing**: All agents run hourly, predictable behavior
+
+### Negative
+- **🚨 BREAKING CHANGE**: All existing agents must migrate to dual-hook pattern
+- **Reduced Frequency for Manual Labels**: Reply Drafter now runs hourly instead of every 30 minutes for manually-labeled emails
+- **API Complexity**: Registration requires object parameter instead of simple function
+- **Learning Curve**: Developers must understand when to use each hook
+- **Migration Effort**: All three existing agents required updates
+
+### Neutral
+- **Hook Selection Flexibility**: Agents choose which hooks they need (onLabel-only, postLabel-only, or both)
+- **Idempotency Still Required**: Agents must implement application-level checks for duplicate prevention
+- **No Performance Change**: Same number of emails processed, just different execution pattern
+
+## Implementation Notes
+
+### Migration Impact
+
+**All agents MUST migrate from old pattern to new pattern. The old single-function handler pattern is no longer supported.**
+
+#### Migrated Agents
+
+**Reply Drafter (AgentReplyDrafter.gs):**
+- **Before**: Single handler + separate 30-minute scheduled trigger
+- **After**: Dual hooks (immediate draft + hourly scan for manual labels)
+- **Changes**:
+  - Removed `installReplyDrafterTrigger()` function
+  - Removed `runReplyDrafter()` scheduled entry point
+  - Implemented `replyDrafterOnLabel_()` for immediate drafts
+  - Implemented `replyDrafterPostLabel_()` for manual label scanning
+  - Registration changed to `{ onLabel, postLabel }` object
+- **Impact**: Manual labels now processed hourly instead of every 30 minutes
+
+**Email Summarizer (AgentSummarizer.gs):**
+- **Before**: Single handler (onLabel-only behavior)
+- **After**: Dual-hook registration (onLabel-only, postLabel omitted)
+- **Changes**:
+  - Wrapped existing handler in `{ onLabel: summarizerHandler }` object
+  - No behavioral change (still immediate-only)
+- **Impact**: Registration syntax updated for consistency
+
+**Template Agent (AgentTemplate.gs):**
+- **Before**: Outdated template showing old pattern
+- **After**: Complete rewrite demonstrating dual-hook pattern
+- **Changes**:
+  - Added `templateAgentOnLabel_()` example
+  - Added `templateAgentPostLabel_()` example
+  - Updated documentation to explain hook selection
+  - Added ADR-018 reference
+- **Impact**: Template now shows best practices for new agents
+
+### Hook Selection Guide
+
+**Use `onLabel` only when:**
+- Agent needs immediate per-email action
+- No need to catch manually-labeled emails
+- Example: Email Summarizer (archive on label, scheduled summary runs separately)
+
+**Use `postLabel` only when:**
+- Agent needs periodic inbox scanning
+- No immediate action required
+- Example: Cleanup agent that processes old emails
+
+**Use both hooks when:**
+- Immediate action for auto-classified emails
+- Need to catch manually-labeled emails
+- Example: Reply Drafter (immediate drafts + scan for manual labels)
+
+### Context Objects
+
+**onLabel Context (`ctx` parameter):**
+```javascript
+{
+  label: 'reply_needed',           // Label being applied
+  decision: {                      // Classification result
+    required_action: 'reply_needed',
+    reason: 'Email asks question'
+  },
+  threadId: 'thread_123',          // Gmail thread ID
+  thread: GmailThread,             // Full GmailThread object
+  cfg: { DEBUG: true, ... },       // Configuration
+  dryRun: false,                   // Dry-run mode flag
+  log: function(msg) { ... }       // Logging function
+}
+```
+
+**postLabel Context:**
+```javascript
+// No parameters provided
+// Hook scans inbox independently using GmailService functions:
+const threads = findEmailsByLabelWithAge_('label_name', maxAgeDays);
+```
+
+### Error Handling
+
+**onLabel Errors:**
+- Caught and logged per agent
+- Don't block other agents on same label
+- Don't block postLabel hooks
+- Return `{ status: 'error', info: errorMessage }`
+
+**postLabel Errors:**
+- Caught and logged per agent
+- Don't block other agents
+- Stats tracked separately: `{ executed, skipped, errors }`
+- Soft timeout warnings if `timeoutMs` exceeded
+
+### Budget and Performance
+
+**Budget Tracking:**
+- `onLabel` hooks count against `AGENTS_BUDGET_PER_RUN` (default: 50)
+- Budget only applies to onLabel hooks (per-email)
+- `postLabel` hooks don't count against per-run budget (one-time execution)
+
+**Performance:**
+- Both hooks run in same execution (no additional trigger overhead)
+- `postLabel` hooks should implement efficient label searches
+- Use `findEmailsByLabelWithAge_()` for optimal performance
+- Soft timeout warnings help identify slow agents
+
+### Testing and Debugging
+
+**Debug Logging:**
+```javascript
+// In Organizer.apply_():
+console.log('Running onLabel for thread: ' + threadId);
+
+// In Agents.runPostLabelHandlers():
+Logger.log('Running postLabel handlers for ' + allAgents.length + ' agents...');
+Logger.log('postLabel handlers complete: executed=X, skipped=Y, errors=Z');
+```
+
+**Dry-Run Behavior:**
+- `onLabel` hooks respect `ctx.dryRun` flag
+- Agents should check `ctx.dryRun` and return without side effects
+- `postLabel` hooks can check `cfg.DRY_RUN` if needed
+
+## References
+
+- ADR-004: Pluggable Agents Architecture (original framework)
+- ADR-011: Self-Contained Agent Architecture (independence pattern)
+- ADR-016: Label-Synchronized Agent State (idempotency via labels)
+- ADR-017: Remove UserProperties Idempotency Mechanism (application-level checks)
+- AgentReplyDrafter.gs: Reference implementation of dual-hook pattern
+- AgentTemplate.gs: Template demonstrating hook selection and patterns

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,6 +38,7 @@ All ADRs in this project follow a consistent format defined in [template.md](tem
 - [ADR-015: INSTRUCTIONS vs KNOWLEDGE Configuration Naming Convention](015-instructions-knowledge-naming.md)
 - [ADR-016: Label-Synchronized Agent State Management](016-label-synchronized-agent-state.md) (Superseded by ADR-017)
 - [ADR-017: Remove UserProperties-Based Agent Idempotency](017-remove-userproperties-idempotency.md)
+- [ADR-018: Dual-Hook Agent Architecture](018-dual-hook-agent-architecture.md) ⚠️ Breaking Change
 
 ## Status Legend
 

--- a/docs/agents/reply-drafter.md
+++ b/docs/agents/reply-drafter.md
@@ -7,16 +7,16 @@ The Reply Drafter is an intelligent agent that automatically creates draft repli
 The Reply Drafter agent:
 
 - **Monitors** emails labeled as `reply_needed` by the core classification system
-- **Processes both new and existing emails** through dual execution modes (see below)
+- **Processes both new and existing emails** through dual-hook architecture (see below)
 - **Checks idempotency** to ensure drafts aren't created multiple times
 - **Fetches optional knowledge** from Google Drive for personalized drafting style
 - **Retrieves full thread context** including all messages in the conversation
 - **Generates professional drafts** using AI with full thread awareness
 - **Creates Gmail draft replies** automatically attached to the original thread
-- **Runs continuously** via both immediate processing and scheduled batch runs
+- **Runs automatically** via the hourly email processing trigger (no separate trigger needed)
 - **Respects dry-run mode** for safe testing before enabling
 
-This agent operates automatically through two complementary execution modes, requiring no manual intervention once configured.
+This agent operates automatically using the dual-hook pattern, requiring no manual intervention once configured.
 
 ## Perfect For
 
@@ -36,67 +36,67 @@ This agent operates automatically through two complementary execution modes, req
 
 ### Setup Steps
 
-1. **Enable the agent** (already enabled by default):
-   - The Reply Drafter is active as soon as emails receive the `reply_needed` label
-   - Agent handler runs automatically during core email processing (no trigger needed)
-   - Works immediately with default professional drafting style
-
-2. **Install scheduled batch trigger** (recommended):
+1. **Install core email processing trigger** (required):
    - Open Apps Script editor: `npm run open:personal` (or `:work`)
-   - Select `installReplyDrafterTrigger` from the function dropdown
-   - Click the Run button (▶️) to install the trigger
+   - Select `installTrigger` from the function dropdown
+   - Click the Run button (▶️) to install the hourly trigger
    - Grant necessary permissions when prompted
-   - The scheduled batch will run every 30 minutes to process existing labeled emails
+   - Reply Drafter runs automatically as part of this hourly cycle
+
+2. **Enable the agent** (already enabled by default):
+   - The Reply Drafter is active as soon as emails receive the `reply_needed` label
+   - Works immediately with default professional drafting style
+   - Both hooks (onLabel + postLabel) run during each hourly email processing cycle
 
 3. **Customize drafting style** (optional):
    - Create a Google Doc with your drafting instructions (tone, style, length)
    - Configure `REPLY_DRAFTER_INSTRUCTIONS_URL` with the document URL
    - See [Knowledge Customization](#knowledge-customization) section below
 
-3. **Add contextual knowledge** (optional):
+4. **Add contextual knowledge** (optional):
    - Create a Google Drive folder with example replies or reference material
    - Configure `REPLY_DRAFTER_KNOWLEDGE_FOLDER_URL` with the folder URL
    - Set `REPLY_DRAFTER_KNOWLEDGE_MAX_DOCS` to limit documents fetched
 
-4. **Test the agent**:
+5. **Test the agent**:
    - Enable debug mode: `REPLY_DRAFTER_DEBUG=true`
-   - Run the core email labeling process
+   - Run the core email labeling process (or wait for hourly trigger)
    - Check Gmail for draft replies on `reply_needed` emails
-   - Review execution logs for detailed operation
+   - Review execution logs for onLabel and postLabel handler execution
 
 ## How It Works
 
-### Dual Execution Modes
+### Dual-Hook Architecture
 
-The Reply Drafter operates in two complementary modes to ensure comprehensive draft coverage:
+The Reply Drafter uses a **dual-hook pattern** to ensure comprehensive draft coverage within the hourly email processing cycle:
 
-#### Mode 1: Agent Handler (Immediate Processing)
+#### Hook 1: onLabel (Immediate Processing)
 Runs during the core email classification pipeline:
 - **Trigger**: Email is newly classified as `reply_needed`
-- **Timing**: Immediately after labeling completes
+- **Timing**: Immediately after labeling completes during `Organizer.apply_()`
 - **Coverage**: Only newly-classified emails
 - **Use case**: Fast draft creation for incoming emails
 
-#### Mode 2: Scheduled Batch Processing (Comprehensive Coverage)
-Runs every 30 minutes on a scheduled trigger:
-- **Trigger**: Time-based (every 30 minutes)
-- **Timing**: Independent of email classification
+#### Hook 2: postLabel (Inbox Scanning)
+Runs after all classification/labeling is complete:
+- **Trigger**: After `Organizer.apply_()` finishes all labeling
+- **Timing**: Once per hourly email processing cycle
 - **Coverage**: ALL emails with `reply_needed` label in inbox
-- **Use case**: Manually labeled emails, retries for failed drafts, emails labeled before agent existed
+- **Use case**: Manually labeled emails, retries for failed drafts, emails labeled before agent was deployed
 
-**Why both modes?**
-The agent handler only processes emails during classification. It never sees:
+**Why both hooks?**
+The onLabel hook only processes emails during active classification. It never sees:
 - Emails you manually label with `reply_needed`
 - Emails that had `reply_needed` before the agent was deployed
 - Emails where draft creation previously failed
 
-The scheduled batch processor fills this gap by searching for ALL `reply_needed` emails and creating drafts for any that don't have one yet.
+The postLabel hook fills this gap by scanning the inbox for ALL `reply_needed` emails and creating drafts for any that don't have one yet. Both hooks run in the same hourly email processing cycle.
 
-### Workflow (Both Modes)
+### Workflow (Both Hooks)
 
 1. **Email Discovery**:
-   - Agent handler: Receives email from classification pipeline
-   - Scheduled batch: Searches inbox for `label:reply_needed`
+   - onLabel: Receives email context from classification pipeline
+   - postLabel: Searches inbox for `in:inbox label:reply_needed`
 2. **Idempotency Check**: Verifies no draft already exists for the thread
 3. **Knowledge Fetching**: Retrieves optional instructions and context from Google Drive
 4. **Thread Retrieval**: Fetches full email conversation (all messages in thread)
@@ -145,23 +145,23 @@ Add these properties to Script Properties in the Apps Script editor:
 
 ### Trigger Installation
 
-The scheduled batch processor requires manual trigger installation:
+The Reply Drafter runs automatically via the dual-hook pattern within the hourly email processing trigger:
 
-1. **Open Apps Script editor**:
+1. **Install core email processing trigger** (required):
    ```bash
    npm run open:personal  # or open:work for work account
    ```
 
-2. **Install trigger**:
-   - Select `installReplyDrafterTrigger` from the function dropdown
+2. **Select and run trigger installer**:
+   - Select `installTrigger` from the function dropdown
    - Click the Run button (▶️)
    - Grant necessary permissions when prompted
 
 3. **Verify installation**:
    - Click "Triggers" in the left sidebar
-   - Confirm `runReplyDrafter` trigger appears with "Every 30 minutes" schedule
+   - Confirm `run` trigger appears with "Every hour" schedule
 
-**Note**: The agent handler requires no trigger installation - it runs automatically as part of the core email processing pipeline.
+**Note**: Both onLabel and postLabel hooks run automatically within this hourly trigger. No separate trigger needed for the Reply Drafter.
 
 ### Configuration Examples
 
@@ -169,7 +169,7 @@ The scheduled batch processor requires manual trigger installation:
 ```
 REPLY_DRAFTER_ENABLED = true
 ```
-**Note**: Also install the scheduled batch trigger (see above) for comprehensive coverage.
+**Note**: Runs automatically via hourly email processing trigger (no separate trigger needed).
 
 **Custom drafting style** (instructions only):
 ```
@@ -569,40 +569,42 @@ The Reply Drafter follows the [self-contained agent architecture](../../docs/adr
 
 - **Self-registration**: Automatically registers with `AGENT_MODULES.push()` pattern
 - **Independent configuration**: Manages own Script Properties without modifying core Config.gs
-- **Dual-mode execution**: Agent handler (no trigger) + scheduled batch processor (30-minute trigger)
+- **Dual-hook execution**: onLabel (immediate) + postLabel (inbox scan) within hourly trigger
 - **Idempotent execution**: Safe to re-run without side effects
 - **Full error handling**: Comprehensive logging and graceful degradation
 
-### Dual Execution Architecture
+### Dual-Hook Architecture
 
-The Reply Drafter mirrors the Email Summarizer's dual-mode pattern:
+The Reply Drafter uses the dual-hook pattern introduced in ADR-018:
 
-**Agent Handler** (`processReplyNeeded_`):
-- Runs within classification pipeline
-- No trigger required
+**onLabel Hook** (`replyDrafterOnLabel_`):
+- Runs during `Organizer.apply_()` for each email being labeled
+- No trigger required (runs within hourly email processing)
 - Processes newly-classified emails only
 - Fast, immediate draft creation
 
-**Scheduled Batch** (`runReplyDrafter`):
-- Runs every 30 minutes via time trigger
-- Requires manual trigger installation
+**postLabel Hook** (`replyDrafterPostLabelScan_`):
+- Runs via `Agents.runPostLabelHandlers()` after all labeling complete
+- No separate trigger required (runs within hourly email processing)
 - Processes ALL `reply_needed` emails in inbox
 - Catches manually labeled emails, retries, and historical emails
 
-This architecture ensures comprehensive coverage - no `reply_needed` email goes without a draft, regardless of how it got the label.
+This architecture ensures comprehensive coverage - no `reply_needed` email goes without a draft, regardless of how it got the label. Both hooks run automatically within the single hourly email processing trigger.
 
 ### Integration with Core System
 
 **Agent Registration:**
 ```javascript
-// From AgentReplyDrafter.gs
+// From AgentReplyDrafter.gs - Dual-Hook Pattern
 AGENT_MODULES.push(function(api) {
   api.register(
     'reply_needed',           // Label to trigger on
     'ReplyDrafter',           // Agent name
-    processReplyNeeded_,      // Handler function
     {
-      idempotentKey: function(ctx) { return 'replyDrafter:' + ctx.threadId; },
+      onLabel: replyDrafterOnLabel_,           // Immediate per-email action
+      postLabel: replyDrafterPostLabelScan_    // Inbox-wide scan
+    },
+    {
       runWhen: 'afterLabel',  // Run after labeling
       timeoutMs: 30000,       // Soft timeout guidance
       enabled: true           // Enabled by default
@@ -658,13 +660,13 @@ const draftText = generateReplyDraft_(prompt, model, projectId, location, apiKey
 
 **Solution**: Check that core email labeling is applying `reply_needed` labels
 
-**Solution**: Install scheduled batch trigger using `installReplyDrafterTrigger` function
+**Solution**: Verify core email processing trigger (`installTrigger`) is installed and running hourly
 
-**Solution**: Enable `REPLY_DRAFTER_DEBUG=true` and check execution logs
+**Solution**: Enable `REPLY_DRAFTER_DEBUG=true` and check execution logs for both onLabel and postLabel execution
 
 **Solution**: Test with `REPLY_DRAFTER_DRY_RUN=true` to verify agent runs without draft creation
 
-**Solution**: For manually labeled emails, wait for next 30-minute scheduled run or run `runReplyDrafter` manually in Apps Script editor
+**Solution**: For manually labeled emails, postLabel hook will process them on next hourly run
 
 ### Drafts not appearing in Gmail
 
@@ -802,6 +804,7 @@ Supporting services:
 - [ADR-010: PromptBuilder and LLMService Separation](../../docs/adr/010-promptbuilder-llmservice-separation.md) - Prompt engineering patterns
 - [ADR-011: Self-Contained Agent Architecture](../../docs/adr/011-self-contained-agents.md) - Independent agent lifecycle
 - [ADR-015: INSTRUCTIONS vs KNOWLEDGE Naming Convention](../../docs/adr/015-instructions-knowledge-naming.md) - Configuration property naming
+- [ADR-018: Dual-Hook Agent Architecture](../../docs/adr/018-dual-hook-agent-architecture.md) - Current execution model (onLabel + postLabel)
 
 ### Agent Context API
 

--- a/src/AgentSummarizer.gs
+++ b/src/AgentSummarizer.gs
@@ -454,17 +454,24 @@ if (typeof AGENT_MODULES === 'undefined') {
 AGENT_MODULES.push(function(api) {
   /**
    * Register Email Summarizer agent for "summarize" label
-   * Agent acknowledges emails and queues them for batch processing
+   * Agent acknowledges emails via onLabel (immediate archive if enabled)
+   * Separate daily trigger handles actual summarization (runEmailSummarizer)
+   *
+   * Uses dual-hook pattern:
+   * - onLabel: Immediate archive when label applied (if enabled)
+   * - postLabel: null (uses separate daily trigger instead)
    */
   api.register(
     'summarize',           // Label to trigger on
     'emailSummarizer',     // Agent name
-    summarizerAgentHandler, // Handler function
+    {
+      onLabel: summarizerAgentHandler,  // Immediate archive behavior
+      postLabel: null                    // Uses separate daily trigger
+    },
     {
       runWhen: 'afterLabel',  // Run after labeling (respects dry-run)
       timeoutMs: 30000,       // Soft timeout guidance
       enabled: true           // Enabled by default
-      // ADR-017: Removed idempotentKey - archiving is naturally idempotent
     }
   );
 });

--- a/src/Agents.gs
+++ b/src/Agents.gs
@@ -6,16 +6,60 @@ var Agents = (function() {
     return typeof f === 'function';
   }
 
-  function register(label, name, handler, options) {
-    if (!label || !name || !isFunction_(handler)) return;
+  /**
+   * Register an agent with dual-hook pattern (onLabel + postLabel)
+   *
+   * @param {string} label - Gmail label to trigger on
+   * @param {string} name - Agent name for logging
+   * @param {Object} hooks - Object with onLabel and/or postLabel functions
+   *   - onLabel: Called per-email during labeling (immediate action)
+   *   - postLabel: Called once after all labeling (inbox-wide scan)
+   * @param {Object} options - Configuration options
+   */
+  function register(label, name, hooks, options) {
+    if (!label || !name) {
+      throw new Error('Agent registration requires label and name');
+    }
+
+    // Validate hooks parameter - must be object with at least one hook
+    if (typeof hooks !== 'object' || hooks === null) {
+      throw new Error('Agent "' + name + '": hooks parameter must be an object with onLabel and/or postLabel');
+    }
+
+    var onLabel = hooks.onLabel || null;
+    var postLabel = hooks.postLabel || null;
+
+    // Require at least one hook
+    if (!onLabel && !postLabel) {
+      throw new Error('Agent "' + name + '": must provide at least one hook (onLabel or postLabel)');
+    }
+
+    // Validate hook types
+    if (onLabel && !isFunction_(onLabel)) {
+      throw new Error('Agent "' + name + '": onLabel must be a function');
+    }
+    if (postLabel && !isFunction_(postLabel)) {
+      throw new Error('Agent "' + name + '": postLabel must be a function');
+    }
+
     var list = registryByLabel.get(label);
     if (!list) {
       list = [];
       registryByLabel.set(label, list);
     }
-    list.push({ name: name, handler: handler, options: options || {} });
+
+    list.push({
+      name: name,
+      onLabel: onLabel,
+      postLabel: postLabel,
+      options: options || {}
+    });
   }
 
+  /**
+   * Run onLabel handlers for a specific label
+   * Called during labeling to provide immediate per-email actions
+   */
   function runFor(label, ctx) {
     var results = [];
     var cfg = ctx && ctx.cfg || {};
@@ -36,6 +80,12 @@ var Agents = (function() {
     for (var i = 0; i < list.length; i++) {
       var item = list[i];
 
+      // Skip if agent doesn't have onLabel hook
+      if (!item.onLabel) {
+        results.push({ agent: item.name, status: 'skip', info: 'no-onLabel-hook' });
+        continue;
+      }
+
       // Respect per-agent enabled flag (default: enabled)
       var isEnabled = !(item.options && item.options.enabled === false);
       if (!isEnabled) {
@@ -55,18 +105,101 @@ var Agents = (function() {
         continue;
       }
 
-      // ADR-017: Removed UserProperties-based idempotency tracking
-      // Agents implement application-level idempotency checks as needed
-
       try {
         runCountThisExecution++;
-        var result = item.handler(ctx) || { status: 'ok' };
+        var result = item.onLabel(ctx) || { status: 'ok' };
         results.push({ agent: item.name, status: result.status || 'ok', info: result.info, retryAfterMs: result.retryAfterMs });
       } catch (e) {
         results.push({ agent: item.name, status: 'error', info: (e && e.toString ? e.toString() : String(e)) });
       }
     }
     return results;
+  }
+
+  /**
+   * Run postLabel handlers for all agents
+   * Called once after all labeling is complete
+   * Enables inbox-wide scans to catch manually-labeled emails
+   */
+  function runPostLabelHandlers(cfg) {
+    cfg = cfg || {};
+
+    if (cfg.AGENTS_ENABLED === false) {
+      return { total: 0, executed: 0, skipped: 0, errors: 0 };
+    }
+
+    var stats = { total: 0, executed: 0, skipped: 0, errors: 0 };
+
+    // Get all unique agents across all labels
+    var allAgents = [];
+    var seenNames = {};
+
+    registryByLabel.forEach(function(list) {
+      list.forEach(function(agent) {
+        if (!seenNames[agent.name]) {
+          seenNames[agent.name] = true;
+          allAgents.push(agent);
+        }
+      });
+    });
+
+    if (cfg.DEBUG) {
+      Logger.log('Running postLabel handlers for ' + allAgents.length + ' agents...');
+    }
+
+    allAgents.forEach(function(agent) {
+      stats.total++;
+
+      // Skip if no postLabel hook
+      if (!agent.postLabel) {
+        stats.skipped++;
+        return;
+      }
+
+      // Respect enabled flag
+      var isEnabled = !(agent.options && agent.options.enabled === false);
+      if (!isEnabled) {
+        stats.skipped++;
+        if (cfg.DEBUG) {
+          Logger.log('Skipping ' + agent.name + ' postLabel (disabled)');
+        }
+        return;
+      }
+
+      try {
+        var startTime = Date.now();
+
+        if (cfg.DEBUG) {
+          Logger.log('Running postLabel for ' + agent.name);
+        }
+
+        agent.postLabel();
+
+        var duration = Date.now() - startTime;
+        stats.executed++;
+
+        if (cfg.DEBUG) {
+          Logger.log(agent.name + ' postLabel completed in ' + duration + 'ms');
+        }
+
+        // Soft timeout warning
+        if (agent.options && agent.options.timeoutMs && duration > agent.options.timeoutMs) {
+          Logger.log('⚠️  ' + agent.name + ' postLabel exceeded soft timeout (' + agent.options.timeoutMs + 'ms)');
+        }
+      } catch (e) {
+        stats.errors++;
+        Logger.log('❌ ' + agent.name + ' postLabel failed: ' + (e && e.toString ? e.toString() : String(e)));
+        if (cfg.DEBUG && e && e.stack) {
+          Logger.log(e.stack);
+        }
+      }
+    });
+
+    if (cfg.DEBUG || stats.executed > 0) {
+      Logger.log('postLabel handlers complete: executed=' + stats.executed + ', skipped=' + stats.skipped + ', errors=' + stats.errors);
+    }
+
+    return stats;
   }
 
   function registerAllModules() {
@@ -94,6 +227,7 @@ var Agents = (function() {
   return {
     register: register,
     runFor: runFor,
+    runPostLabelHandlers: runPostLabelHandlers,
     registerAllModules: registerAllModules
   };
 })();
@@ -135,5 +269,3 @@ function clearAllAgentIdempotencyKeys() {
   console.log('Migration complete: ' + JSON.stringify(summary, null, 2));
   return summary;
 }
-
-


### PR DESCRIPTION
## Overview

⚠️ **BREAKING CHANGE**: This PR implements a new dual-hook agent architecture that replaces the single-function registration pattern.

Closes #26

## What Changed

### Core Framework

**[Agents.gs](src/Agents.gs)**
- ✅ Replaced single-function handler with `{ onLabel, postLabel }` object registration
- ✅ Added `runPostLabelHandlers()` for inbox-wide scanning
- ✅ Comprehensive validation requiring at least one hook
- ✅ Removed backward compatibility (BREAKING CHANGE)

**[Organizer.gs](src/Organizer.gs)**
- ✅ Calls `Agents.runPostLabelHandlers()` after all labeling complete
- ✅ Aggregates postLabel stats into agent metrics

### Agent Migrations

**[AgentReplyDrafter.gs](src/AgentReplyDrafter.gs)**
- ✅ Migrated to dual-hook pattern
- ✅ `onLabel`: Immediate draft creation during classification
- ✅ `postLabel`: Inbox scan for manually-labeled emails
- ✅ **REMOVED** separate trigger functions (no longer needed):
  - `installReplyDrafterTrigger()`
  - `deleteReplyDrafterTriggers_()`
  - `listReplyDrafterTriggers()`
- ⚠️ Now runs hourly instead of every 30 minutes for manual labels

**[AgentSummarizer.gs](src/AgentSummarizer.gs)**
- ✅ Updated to dual-hook registration (onLabel only, postLabel null)
- ✅ Behavior unchanged, just new syntax

**[AgentTemplate.gs](src/AgentTemplate.gs)**
- ✅ Complete rewrite demonstrating dual-hook pattern
- ✅ Shows three registration options with examples
- ✅ Clear hook selection guidance

### Documentation

**Updated Files:**
- [CLAUDE.md](CLAUDE.md) - Dual-hook pattern now only supported method
- [docs/agents/reply-drafter.md](docs/agents/reply-drafter.md) - Removed trigger installation
- [docs/developer-guide.md](docs/developer-guide.md) - Updated all examples
- [docs/adr/004-pluggable-agents.md](docs/adr/004-pluggable-agents.md) - Updated references
- [docs/adr/011-self-contained-agents.md](docs/adr/011-self-contained-agents.md) - Updated pattern
- [docs/adr/README.md](docs/adr/README.md) - Added ADR-018

**New Files:**
- [docs/adr/018-dual-hook-agent-architecture.md](docs/adr/018-dual-hook-agent-architecture.md) - Complete ADR

## Architecture

### Before: Single-Function Handler
```javascript
api.register('reply_needed', 'ReplyDrafter', processReplyNeeded_, {
  runWhen: 'afterLabel'
});

// Separate trigger needed
function installReplyDrafterTrigger() { ... }
```

### After: Dual-Hook Pattern
```javascript
api.register('reply_needed', 'ReplyDrafter', {
  onLabel: processReplyNeeded_,         // Immediate per-email
  postLabel: replyDrafterPostLabelScan_  // Inbox scan
}, {
  runWhen: 'afterLabel'
});

// No separate trigger - runs in hourly cycle
```

## Execution Flow

### Hourly Trigger: `processNewEmails()`
1. Find unprocessed emails
2. Classify with AI
3. Apply labels → **onLabel hooks fire per-email** (immediate action)
4. All labeling complete → **postLabel hooks fire** (inbox-wide scans)
5. Done

### Hook Purposes

**onLabel** (per-email immediate action):
- Called once per email as label is applied
- Receives context: `{ thread, threadId, label, cfg, ... }`
- Use for: Draft reply, forward email, notify
- Returns: `{ status: 'ok'|'skip'|'error', info: '...' }`

**postLabel** (inbox-wide scanning):
- Called once after all labeling complete
- No parameters (scans inbox independently)
- Use for: Catch manually-labeled emails, cleanup, batch operations
- Returns: Nothing (void function)

## Benefits

✅ **Zero trigger proliferation** - Single hourly trigger handles all agents  
✅ **Immediate actions** - Auto-classified emails processed instantly  
✅ **Catches manual labels** - Inbox scans within the hour  
✅ **Simpler architecture** - No separate trigger management  
✅ **Clean separation** - onLabel (immediate) vs postLabel (scanning)  
✅ **Future-proof** - Todo Forwarder and other agents can use this pattern  

## Breaking Changes

⚠️ **All agents must migrate** to dual-hook registration  
⚠️ **Reply Drafter timing** changed from 30-minute to hourly for manual labels  
⚠️ **Registration syntax** changed to `{ onLabel, postLabel }` object  
⚠️ **No backward compatibility** - old single-function pattern removed  

## Migration Required

All existing agents need to update their registration:

**Old:**
```javascript
api.register('label', 'Name', handlerFn, options);
```

**New (at least one hook required):**
```javascript
api.register('label', 'Name', {
  onLabel: handlerFn,     // Optional
  postLabel: scannerFn    // Optional
}, options);
```

## Testing Checklist

### Reply Drafter Tests
- [ ] Auto-classified email gets immediate draft (onLabel)
- [ ] Manually-labeled email gets draft within hour (postLabel)
- [ ] No duplicate drafts created (idempotency working)
- [ ] Both hooks execute correctly in logs

### Email Summarizer Tests
- [ ] Immediate archive still works (onLabel)
- [ ] Daily summary trigger still works (separate trigger)
- [ ] No errors from postLabel being null

### General Tests
- [ ] `DEBUG=true` shows both onLabel and postLabel execution
- [ ] Error in onLabel doesn't prevent postLabel from running
- [ ] Dry-run mode works for both hooks
- [ ] Agent stats show correct counts

## Files Changed

**Source Code (5 files):**
- `src/Agents.gs` - Framework changes
- `src/Organizer.gs` - postLabel orchestration
- `src/AgentReplyDrafter.gs` - Dual-hook migration
- `src/AgentSummarizer.gs` - Registration update
- `src/AgentTemplate.gs` - Complete rewrite

**Documentation (8 files):**
- `CLAUDE.md` - Project documentation
- `docs/agents/reply-drafter.md` - Agent guide
- `docs/developer-guide.md` - Developer reference
- `docs/adr/README.md` - ADR index
- `docs/adr/004-pluggable-agents.md` - Updated references
- `docs/adr/011-self-contained-agents.md` - Updated pattern
- `docs/adr/018-dual-hook-agent-architecture.md` - **NEW ADR**

**Total: 13 files changed** (12 modified, 1 created)

## Deployment Notes

After merging:
1. Deploy to test account first
2. Monitor logs for onLabel and postLabel execution
3. Verify Reply Drafter works for both auto and manual labels
4. No trigger installation needed (removed from deployment scripts)
5. Test with `DEBUG=true` to see dual-hook execution

## References

- Issue: #26
- ADR: [018-dual-hook-agent-architecture.md](docs/adr/018-dual-hook-agent-architecture.md)
- Related ADRs: ADR-004 (Pluggable Agents), ADR-011 (Self-Contained Agents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)