### PR TITLE
Fix installTrigger schedule type (fixes #40)

### DIFF
--- a/src/Main.gs
+++ b/src/Main.gs
@@ -73,7 +73,7 @@ function run() {
 
 function installTrigger() {
   // Use shared utility for trigger management
-  const result = createTimeTrigger_('run', { type: 'hourly', interval: 1 });
+  const result = createTimeTrigger_('run', { type: 'hours', interval: 1 });
   if (!result.success) {
     console.log('Failed to install trigger: ' + result.error);
   }


### PR DESCRIPTION
## Summary

Fixes the `installTrigger()` function which was failing with "Unknown schedule type: hourly" error.

Closes #40

## Root Cause

The `installTrigger()` function in `src/Main.gs` was passing `type: 'hourly'` to `createTimeTrigger_()`, but the utility function expects `type: 'hours'` (plural).

## Changes Made

**src/Main.gs:76**
```diff
- const result = createTimeTrigger_('run', { type: 'hourly', interval: 1 });
+ const result = createTimeTrigger_('run', { type: 'hours', interval: 1 });
```

## Testing

✅ Tested in Apps Script editor:
1. Selected `installTrigger` function
2. Clicked Run
3. No error - trigger installed successfully
4. Verified with `listTriggers` - shows "Found 1 email processing trigger(s)"
5. Confirmed in Triggers UI - hourly trigger is active

## Impact

- **Severity**: High - prevents automatic email processing setup
- **Fix**: One-word change (`'hourly'` → `'hours'`)
- **Risk**: Very low - simple parameter fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)