### PR TITLE
Implement Slack Notifier Agent (Issue #51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,27 @@ Successfully forwarded emails are automatically archived (with `todo` label pres
 
 [Todo Forwarder Documentation →](docs/agents/todo-forwarder.md)
 
+### Slack Notifier Agent
+
+**What it adds**: Real-time Slack notifications when labels are applied to emails
+
+Perfect for keeping teams informed about email classifications, monitoring urgent emails, or integrating Gmail labeling with Slack workflows. Configurable label filtering lets you notify only for important labels.
+
+**How it works**:
+- Immediate notifications via Slack webhook when labels are applied (onLabel hook)
+- Rich message formatting with email details, subject, sender, and Gmail link
+- Color-coded by label type for easy visual distinction
+- Runs automatically during email classification (no separate trigger needed)
+
+**Quick configuration example**:
+```
+SLACK_WEBHOOK_URL = https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+SLACK_ENABLED = true
+SLACK_LABELS = ["reply_needed","todo"]
+```
+
+[Slack Notifier Documentation →](docs/agents/slack-notifier.md)
+
 ### Interactive Web App Dashboard
 
 **What it adds**: Mobile-optimized web interface for on-demand email summarization
@@ -211,6 +232,7 @@ Teach the AI about your specific email patterns, priorities, and preferences usi
 - [Reply Drafter Agent](docs/agents/reply-drafter.md) — Automatic draft replies with AI
 - [Email Summarizer Agent](docs/agents/email-summarizer.md) — Daily email summaries
 - [Todo Forwarder Agent](docs/agents/todo-forwarder.md) — Automatic todo email forwarding
+- [Slack Notifier Agent](docs/agents/slack-notifier.md) — Real-time Slack notifications for labeling decisions
 - [Web App Dashboard](docs/features/web-app.md) — On-demand summarization interface
 - [Multi-Account Deployment](docs/features/multi-account.md) — Manage multiple accounts
 - [Knowledge System](docs/features/knowledge-system.md) — Customize AI classification

--- a/docs/agents/slack-notifier.md
+++ b/docs/agents/slack-notifier.md
@@ -1,0 +1,290 @@
+# Slack Notifier Agent
+
+The Slack Notifier is an intelligent agent that automatically sends Slack notifications when certain labels are applied to emails, enabling real-time visibility into email classification activity.
+
+## What It Does
+
+The Slack Notifier agent:
+
+- **Monitors** emails labeled by the core classification system
+- **Sends immediate notifications** via Slack webhook when labels are applied
+- **Configurable label filtering** - notify for all labels or specific ones only
+- **Rich message formatting** with email details, subject, sender, and Gmail link
+- **Color-coded by label type** - visual distinction for different label categories
+- **Runs automatically** during email classification (onLabel hook)
+- **Graceful error handling** - failures don't break email processing
+- **Respects dry-run mode** for safe testing before enabling
+
+This agent operates automatically during the email classification process, requiring no manual intervention once configured.
+
+## Perfect For
+
+- **Team visibility**: Keep team members informed about important email classifications
+- **Urgent alerts**: Get notified immediately when critical emails are labeled
+- **Workflow integration**: Connect Gmail labeling to Slack workflows and channels
+- **Activity monitoring**: Track email classification activity in real-time
+- **Multiple account management**: Monitor email processing across different accounts
+
+## Quick Start
+
+### Prerequisites
+
+- Complete the [basic email labeling setup](../../README.md#setup-guide) first
+- Slack Notifier is disabled by default (`SLACK_ENABLED=false`)
+- Core labeling system must be running to apply labels
+- **Required**: Slack webhook URL (`SLACK_WEBHOOK_URL`)
+
+### Setup Steps
+
+1. **Create Slack webhook**:
+   - Go to your Slack workspace settings
+   - Navigate to Apps → Incoming Webhooks
+   - Click "Add to Slack"
+   - Choose a channel for notifications (or use default)
+   - Copy the webhook URL (looks like `https://hooks.slack.com/services/...`)
+
+2. **Configure Slack Notifier**:
+   - In Apps Script editor, go to "Project Settings" → "Script properties"
+   - Add property: `SLACK_WEBHOOK_URL` = your webhook URL from step 1
+   - Add property: `SLACK_ENABLED` = `true`
+   - This is the minimal configuration - notifications will be sent for all labels
+
+3. **Optional: Filter by label**:
+   - To notify only for specific labels, add: `SLACK_LABELS` = `["reply_needed","todo"]`
+   - Use JSON array format: `["label1","label2"]`
+   - Leave unset to notify for all labels (`reply_needed`, `review`, `todo`, `summarize`)
+
+4. **Optional: Customize appearance**:
+   - `SLACK_USERNAME`: Bot username (default: "Email Agent")
+   - `SLACK_CHANNEL`: Override channel (e.g., `#email-alerts`)
+   - `SLACK_ICON_EMOJI`: Emoji icon (default: `:email:`)
+
+5. **Test the agent**:
+   - Enable debug mode: `SLACK_DEBUG=true`
+   - Enable dry-run mode: `DRY_RUN=true` (in global config)
+   - Run the core email labeling process (or wait for hourly trigger)
+   - Check execution logs for "Slack Notifier" messages
+   - Verify notifications appear in Slack channel
+   - Disable dry-run once testing confirms behavior
+
+## How It Works
+
+### onLabel Hook Architecture
+
+The Slack Notifier uses the **onLabel hook** to send immediate notifications:
+
+- **Trigger**: Email is labeled during classification
+- **Timing**: Immediately after labeling completes during `Organizer.apply_()`
+- **Coverage**: All emails that receive labels during classification
+- **Use case**: Real-time notifications as emails are processed
+
+### Workflow
+
+1. **Email Classification**:
+   - Core system analyzes email and decides on label (`reply_needed`, `review`, `todo`, `summarize`)
+   - Label is applied to email thread
+
+2. **Agent Trigger**:
+   - `onLabel` hook fires with context (label, thread, decision, etc.)
+   - Slack Notifier checks if it should notify for this label
+   - If enabled and label matches filter, proceeds to notification
+
+3. **Message Formatting**:
+   - Extracts email details (subject, from, thread ID)
+   - Formats Slack message with attachments
+   - Adds color coding based on label type
+   - Includes Gmail link for easy access
+
+4. **Notification Delivery**:
+   - Sends HTTP POST request to Slack webhook URL
+   - Slack displays formatted message in configured channel
+   - Error handling ensures failures don't break email processing
+
+### Label Filtering
+
+The `SLACK_LABELS` property controls which labels trigger notifications:
+
+- **Not set** (default): Notifies for all labels
+  ```
+  SLACK_ENABLED = true
+  SLACK_WEBHOOK_URL = https://hooks.slack.com/services/...
+  ```
+  Result: Notifications for `reply_needed`, `review`, `todo`, `summarize`
+
+- **Empty array**: Disables notifications
+  ```
+  SLACK_LABELS = []
+  ```
+  Result: No notifications (even if `SLACK_ENABLED=true`)
+
+- **Specific labels**: Only notify for listed labels
+  ```
+  SLACK_LABELS = ["reply_needed","todo"]
+  ```
+  Result: Only notifications for `reply_needed` and `todo` labels
+
+## Configuration Reference
+
+### Required Properties
+
+| Property | Description |
+|----------|-------------|
+| `SLACK_ENABLED` | Enable/disable agent (default: `false`) |
+| `SLACK_WEBHOOK_URL` | Slack webhook URL (required - agent disabled if not set) |
+
+### Optional Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `SLACK_LABELS` | All labels | JSON array of labels to notify about |
+| `SLACK_USERNAME` | `Email Agent` | Bot username for Slack messages |
+| `SLACK_CHANNEL` | Webhook default | Override channel (e.g., `#email-alerts`) |
+| `SLACK_ICON_EMOJI` | `:email:` | Emoji icon for bot messages |
+| `SLACK_DEBUG` | `false` | Enable detailed logging |
+
+### Configuration Examples
+
+**Minimal setup** (notify for all labels):
+```
+SLACK_WEBHOOK_URL = https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+SLACK_ENABLED = true
+```
+
+**Selective notifications** (only urgent labels):
+```
+SLACK_WEBHOOK_URL = https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+SLACK_ENABLED = true
+SLACK_LABELS = ["reply_needed","todo"]
+```
+
+**Custom channel and username**:
+```
+SLACK_WEBHOOK_URL = https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+SLACK_ENABLED = true
+SLACK_LABELS = ["reply_needed"]
+SLACK_CHANNEL = #urgent-emails
+SLACK_USERNAME = Gmail Labeler
+```
+
+**Debug mode**:
+```
+SLACK_WEBHOOK_URL = https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+SLACK_ENABLED = true
+SLACK_DEBUG = true
+```
+
+## Message Format
+
+Slack notifications include:
+
+- **Main message**: "📧 Email labeled: [label]"
+- **Subject**: Email subject line
+- **From**: Sender email address
+- **Label**: Classification label applied
+- **Link**: Direct link to Gmail thread
+- **Reason**: AI classification reason (if available)
+
+Color coding:
+- `reply_needed`: Red (danger)
+- `todo`: Yellow (warning)
+- `review`: Green (good)
+- `summarize`: Green (good)
+
+## Troubleshooting
+
+### Notifications not appearing in Slack
+
+**Check configuration**:
+1. Verify `SLACK_ENABLED=true` in Script Properties
+2. Verify `SLACK_WEBHOOK_URL` is set correctly
+3. Check that webhook URL is valid and active
+4. Verify webhook hasn't been revoked in Slack
+
+**Check label filtering**:
+1. If `SLACK_LABELS` is set, verify it includes the labels being applied
+2. If `SLACK_LABELS=[]`, notifications are disabled even if `SLACK_ENABLED=true`
+3. Check execution logs for "label not in SLACK_LABELS filter" messages
+
+**Check execution logs**:
+1. Enable `SLACK_DEBUG=true` for detailed logging
+2. Check Apps Script execution logs for "Slack Notifier" messages
+3. Look for error messages indicating webhook failures
+
+### Notifications appearing too frequently
+
+**Solution**: Use `SLACK_LABELS` to filter to specific labels:
+```
+SLACK_LABELS = ["reply_needed"]
+```
+
+### Notifications failing silently
+
+**Solution**: Enable debug mode to see errors:
+```
+SLACK_DEBUG = true
+```
+
+Check logs for HTTP errors or webhook issues.
+
+### Dry-run mode not working
+
+**Note**: Dry-run mode respects global `DRY_RUN` setting. If `DRY_RUN=true`, Slack Notifier will skip actual webhook calls but log what it would send.
+
+## Advanced Usage
+
+### Multiple Channel Notifications
+
+If you need notifications in different channels for different labels, you can:
+1. Create multiple webhooks, each pointing to different channels
+2. Use multiple Slack Notifier instances (requires code modification)
+3. Use Slack's webhook default channel and route via Slack rules
+
+### Rate Limiting
+
+Slack webhooks have rate limits. If processing many emails:
+- Consider using `SLACK_LABELS` to filter to important labels only
+- Monitor Slack API rate limit responses
+- Future enhancement: Batch notifications via `postLabel` hook
+
+### Custom Message Formatting
+
+The current implementation uses Slack's standard attachment format. For richer formatting:
+- Use Slack Blocks API (requires code modification)
+- Customize `formatSlackMessage_()` function in `AgentSlackNotifier.gs`
+
+## Related Documentation
+
+- [Configuration Guide](../guides/configuration.md) - Complete configuration reference
+- [Agent Architecture](../../docs/adr/011-self-contained-agents.md) - Self-contained agent pattern
+- [Dual-Hook Architecture](../../docs/adr/018-dual-hook-agent-architecture.md) - Hook system overview
+
+## Implementation Details
+
+### Self-Contained Architecture
+
+The Slack Notifier follows the self-contained agent pattern (ADR-011):
+- Manages own configuration via `getSlackNotifierConfig_()`
+- No changes to core `Config.gs` required
+- Can be enabled/disabled without affecting other agents
+
+### Error Handling
+
+The agent implements graceful error handling:
+- Webhook failures don't break email processing
+- Errors are logged but don't throw exceptions
+- Returns status codes compatible with agent framework
+
+### No Idempotency Needed
+
+Notifications are side effects, not stateful operations:
+- Each labeling event triggers a notification
+- Re-labeling the same email triggers another notification
+- No duplicate tracking needed
+
+### HTTP Implementation
+
+Uses Apps Script's `UrlFetchApp.fetch()` for webhook calls:
+- Standard HTTP POST requests
+- JSON payload format
+- Error handling for HTTP errors and timeouts
+

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -301,6 +301,75 @@ TODO_FORWARDER_DEBUG = true
 TODO_FORWARDER_DRY_RUN = true
 ```
 
+## Slack Notifier Agent Configuration
+
+Settings for the [Slack Notifier Agent](../agents/slack-notifier.md).
+
+**Note**: Slack Notifier configuration is managed in `AgentSlackNotifier.gs` via `getSlackNotifierConfig_()` function, following the self-contained agent architecture pattern.
+
+**Execution Mode**: The Slack Notifier uses the **onLabel hook** to send immediate notifications when labels are applied during email classification.
+
+### Basic Configuration
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `SLACK_ENABLED` | `false` | Enable/disable the Slack Notifier agent |
+| `SLACK_WEBHOOK_URL` | None | Slack webhook URL (required - agent disabled if not set) |
+
+**Label Filtering**: Use `SLACK_LABELS` property to control which labels trigger notifications:
+- **Not set** (default): Notifies for all labels (`reply_needed`, `review`, `todo`, `summarize`)
+- **Empty array** `[]`: Disables notifications (even if `SLACK_ENABLED=true`)
+- **Specific labels** `["reply_needed","todo"]`: Only notifies for specified labels
+
+### Optional Configuration
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `SLACK_LABELS` | All labels | JSON array of labels to notify about (e.g., `["reply_needed","todo"]`) |
+| `SLACK_USERNAME` | `Email Agent` | Bot username for Slack messages |
+| `SLACK_CHANNEL` | Webhook default | Override channel (e.g., `#email-alerts`) |
+| `SLACK_ICON_EMOJI` | `:email:` | Emoji icon for bot messages |
+| `SLACK_DEBUG` | `false` | Enable detailed logging for the agent |
+
+**Configuration examples**:
+
+**Minimal setup** (notify for all labels):
+```
+SLACK_WEBHOOK_URL = https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+SLACK_ENABLED = true
+```
+
+**Selective notifications** (only urgent labels):
+```
+SLACK_WEBHOOK_URL = https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+SLACK_ENABLED = true
+SLACK_LABELS = ["reply_needed","todo"]
+```
+
+**Custom channel and username**:
+```
+SLACK_WEBHOOK_URL = https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+SLACK_ENABLED = true
+SLACK_LABELS = ["reply_needed"]
+SLACK_CHANNEL = #urgent-emails
+SLACK_USERNAME = Gmail Labeler
+```
+
+**Debug mode**:
+```
+SLACK_WEBHOOK_URL = https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+SLACK_ENABLED = true
+SLACK_DEBUG = true
+```
+
+**Setup Instructions**:
+1. Go to your Slack workspace settings
+2. Navigate to Apps → Incoming Webhooks
+3. Click "Add to Slack"
+4. Choose a channel for notifications
+5. Copy the webhook URL
+6. Add to Script Properties as `SLACK_WEBHOOK_URL`
+
 ## Knowledge System Configuration
 
 Settings for the [Knowledge System](../features/knowledge-system.md) (advanced).

--- a/src/AgentSlackNotifier.gs
+++ b/src/AgentSlackNotifier.gs
@@ -1,0 +1,387 @@
+/**
+ * Slack Notifier Agent - Self-Contained Implementation
+ *
+ * This agent implements Slack notifications for labeling decisions:
+ * - Sends Slack notifications when certain labels are applied to emails
+ * - Configurable via Script Properties with minimal setup required
+ * - Supports selective notification by label type
+ * - Graceful error handling (failures don't break email processing)
+ *
+ * Architecture:
+ * - Uses onLabel hook to notify immediately when labels are applied
+ * - Self-contained: manages own config without core Config.gs changes
+ * - No idempotency needed - notifications are side effects
+ *
+ * Features:
+ * - Minimal configuration (only 2 required properties)
+ * - Selective notifications by label type
+ * - Rich Slack message formatting with email details
+ * - Full error handling and dry-run support
+ */
+
+// ============================================================================
+// Configuration Management (Self-Contained)
+// ============================================================================
+
+/**
+ * Get Slack Notifier agent configuration with sensible defaults
+ * Manages own PropertiesService keys without core Config.gs changes
+ *
+ * @return {Object} Configuration object
+ */
+function getSlackNotifierConfig_() {
+  const props = PropertiesService.getScriptProperties();
+  
+  // Parse SLACK_LABELS JSON array (default: all labels if not set)
+  let slackLabels = null;
+  const labelsStr = props.getProperty('SLACK_LABELS');
+  if (labelsStr) {
+    try {
+      slackLabels = JSON.parse(labelsStr);
+      if (!Array.isArray(slackLabels)) slackLabels = null;
+    } catch (e) {
+      // Invalid JSON - default to null (all labels)
+      slackLabels = null;
+    }
+  }
+  
+  return {
+    // Agent enablement
+    SLACK_ENABLED: (props.getProperty('SLACK_ENABLED') || 'false').toLowerCase() === 'true',
+    
+    // Webhook configuration (required)
+    SLACK_WEBHOOK_URL: props.getProperty('SLACK_WEBHOOK_URL'),
+    
+    // Label filtering (null = all labels, [] = disabled, ['label1'] = specific labels)
+    SLACK_LABELS: slackLabels,
+    
+    // Optional customization
+    SLACK_USERNAME: props.getProperty('SLACK_USERNAME') || 'Email Agent',
+    SLACK_CHANNEL: props.getProperty('SLACK_CHANNEL') || null, // null = use webhook default
+    SLACK_ICON_EMOJI: props.getProperty('SLACK_ICON_EMOJI') || ':email:',
+    SLACK_DEBUG: (props.getProperty('SLACK_DEBUG') || 'false').toLowerCase() === 'true'
+  };
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Check if notification should be sent for this label
+ * 
+ * @param {string} label - Label name to check
+ * @param {Object} config - Slack notifier configuration
+ * @return {boolean} True if notification should be sent
+ */
+function shouldNotifyForLabel_(label, config) {
+  // If SLACK_LABELS is null, notify for all labels
+  if (config.SLACK_LABELS === null) {
+    return true;
+  }
+  
+  // If SLACK_LABELS is empty array, disable notifications
+  if (Array.isArray(config.SLACK_LABELS) && config.SLACK_LABELS.length === 0) {
+    return false;
+  }
+  
+  // If SLACK_LABELS is array, check if label is in it
+  if (Array.isArray(config.SLACK_LABELS)) {
+    return config.SLACK_LABELS.indexOf(label) !== -1;
+  }
+  
+  // Default to notify (shouldn't reach here, but safe fallback)
+  return true;
+}
+
+/**
+ * Get label color for Slack message attachment
+ * 
+ * @param {string} label - Label name
+ * @return {string} Slack color code
+ */
+function getLabelColor_(label) {
+  const colorMap = {
+    'reply_needed': 'danger',    // Red
+    'todo': 'warning',            // Yellow
+    'review': 'good',             // Green
+    'summarize': '#36a64f'        // Green (slightly different)
+  };
+  return colorMap[label] || 'good';
+}
+
+/**
+ * Format email thread details for Slack message
+ * 
+ * @param {Object} ctx - Agent context with thread and decision info
+ * @return {Object} Slack message payload
+ */
+function formatSlackMessage_(ctx) {
+  const config = getSlackNotifierConfig_();
+  const thread = ctx.thread;
+  const label = ctx.label;
+  const decision = ctx.decision || {};
+  
+  try {
+    // Get email details
+    const subject = thread.getFirstMessageSubject() || '(No Subject)';
+    const firstMessage = thread.getMessages()[0];
+    const from = firstMessage ? firstMessage.getFrom() : 'Unknown';
+    const threadId = ctx.threadId;
+    
+    // Build Gmail link
+    const gmailUrl = 'https://mail.google.com/mail/u/0/#inbox/' + threadId;
+    
+    // Build Slack message
+    const message = {
+      text: '📧 Email labeled: ' + label,
+      username: config.SLACK_USERNAME,
+      icon_emoji: config.SLACK_ICON_EMOJI,
+      attachments: [{
+        color: getLabelColor_(label),
+        fields: [
+          {
+            title: 'Label',
+            value: label,
+            short: true
+          },
+          {
+            title: 'Subject',
+            value: subject.length > 100 ? subject.substring(0, 97) + '...' : subject,
+            short: true
+          },
+          {
+            title: 'From',
+            value: from.length > 100 ? from.substring(0, 97) + '...' : from,
+            short: true
+          },
+          {
+            title: 'Link',
+            value: '<' + gmailUrl + '|View in Gmail>',
+            short: false
+          }
+        ]
+      }]
+    };
+    
+    // Add reason if available
+    if (decision.reason) {
+      message.attachments[0].footer = 'Reason: ' + decision.reason;
+    }
+    
+    // Add channel if configured
+    if (config.SLACK_CHANNEL) {
+      message.channel = config.SLACK_CHANNEL;
+    }
+    
+    return message;
+    
+  } catch (error) {
+    // Fallback message if we can't get thread details
+    return {
+      text: '📧 Email labeled: ' + label,
+      username: config.SLACK_USERNAME,
+      icon_emoji: config.SLACK_ICON_EMOJI,
+      attachments: [{
+        color: getLabelColor_(label),
+        fields: [
+          {
+            title: 'Label',
+            value: label,
+            short: true
+          },
+          {
+            title: 'Thread ID',
+            value: ctx.threadId,
+            short: true
+          }
+        ],
+        footer: 'Error retrieving email details: ' + error.toString()
+      }]
+    };
+  }
+}
+
+/**
+ * Send Slack notification via webhook
+ * 
+ * @param {string} webhookUrl - Slack webhook URL
+ * @param {Object} payload - Slack message payload
+ * @return {Object} Result object with success status
+ */
+function sendSlackNotification_(webhookUrl, payload) {
+  try {
+    if (!webhookUrl) {
+      return {
+        success: false,
+        error: 'No webhook URL configured'
+      };
+    }
+    
+    const options = {
+      method: 'post',
+      contentType: 'application/json',
+      payload: JSON.stringify(payload),
+      muteHttpExceptions: true
+    };
+    
+    const response = UrlFetchApp.fetch(webhookUrl, options);
+    const responseCode = response.getResponseCode();
+    const responseText = response.getContentText();
+    
+    // Slack returns 200 on success
+    if (responseCode === 200) {
+      return {
+        success: true,
+        message: 'Notification sent successfully'
+      };
+    } else {
+      return {
+        success: false,
+        error: 'HTTP ' + responseCode + ': ' + responseText.substring(0, 200)
+      };
+    }
+    
+  } catch (error) {
+    return {
+      success: false,
+      error: 'Failed to send notification: ' + error.toString()
+    };
+  }
+}
+
+// ============================================================================
+// Main Agent Logic - onLabel Hook
+// ============================================================================
+
+/**
+ * Slack Notifier agent onLabel handler function
+ * Integrates with existing agent framework and context system
+ * ctx provides: label, decision, threadId, thread (GmailThread), cfg, dryRun, log(msg)
+ * Returns { status: 'ok'|'skip'|'retry'|'error', info?: string }
+ */
+function slackNotifierOnLabel_(ctx) {
+  try {
+    const config = getSlackNotifierConfig_();
+    
+    // Check if agent is enabled
+    if (!config.SLACK_ENABLED) {
+      return { status: 'skip', info: 'slack notifier agent disabled' };
+    }
+    
+    // Validate configuration
+    if (!config.SLACK_WEBHOOK_URL) {
+      ctx.log('Slack Notifier: No webhook URL configured');
+      return { status: 'error', info: 'SLACK_WEBHOOK_URL not configured' };
+    }
+    
+    // Check if we should notify for this label
+    if (!shouldNotifyForLabel_(ctx.label, config)) {
+      return { status: 'skip', info: 'label not in SLACK_LABELS filter' };
+    }
+    
+    if (config.SLACK_DEBUG) {
+      ctx.log('Slack Notifier agent running for thread ' + ctx.threadId + ' with label ' + ctx.label);
+    }
+    
+    // Check for dry-run mode
+    if (ctx.dryRun) {
+      ctx.log('DRY RUN - Would send Slack notification for label: ' + ctx.label);
+      return { status: 'ok', info: 'dry-run mode - notification would be sent' };
+    }
+    
+    // Format Slack message
+    const slackMessage = formatSlackMessage_(ctx);
+    
+    // Send notification
+    const result = sendSlackNotification_(config.SLACK_WEBHOOK_URL, slackMessage);
+    
+    if (!result.success) {
+      // Log error but don't throw - failures shouldn't break email processing
+      ctx.log('Slack notification failed: ' + result.error);
+      return { status: 'error', info: result.error };
+    }
+    
+    if (config.SLACK_DEBUG) {
+      ctx.log('Slack notification sent successfully');
+    }
+    
+    return {
+      status: 'ok',
+      info: 'notification sent'
+    };
+    
+  } catch (error) {
+    // Catch all errors and log without throwing - email processing must continue
+    ctx.log('Slack Notifier agent error: ' + error.toString());
+    return { status: 'error', info: error.toString() };
+  }
+}
+
+// ============================================================================
+// Agent Registration
+// ============================================================================
+
+if (typeof AGENT_MODULES === 'undefined') {
+  AGENT_MODULES = [];
+}
+
+AGENT_MODULES.push(function(api) {
+  /**
+   * Register Slack Notifier agent for all labels
+   * Agent sends Slack notifications when configured labels are applied
+   *
+   * Uses onLabel hook pattern:
+   * - Runs immediately when labels are applied during classification
+   * - Configurable label filtering via SLACK_LABELS property
+   */
+  api.register(
+    'reply_needed',              // Register for this label
+    'SlackNotifier',            // Agent name
+    {
+      onLabel: slackNotifierOnLabel_  // Immediate per-email handler
+    },
+    {
+      runWhen: 'afterLabel',    // Run after labeling (respects dry-run)
+      enabled: true             // Enabled by default (can be disabled via config)
+    }
+  );
+  
+  // Register for other labels as well
+  api.register(
+    'review',
+    'SlackNotifier',
+    {
+      onLabel: slackNotifierOnLabel_
+    },
+    {
+      runWhen: 'afterLabel',
+      enabled: true
+    }
+  );
+  
+  api.register(
+    'todo',
+    'SlackNotifier',
+    {
+      onLabel: slackNotifierOnLabel_
+    },
+    {
+      runWhen: 'afterLabel',
+      enabled: true
+    }
+  );
+  
+  api.register(
+    'summarize',
+    'SlackNotifier',
+    {
+      onLabel: slackNotifierOnLabel_
+    },
+    {
+      runWhen: 'afterLabel',
+      enabled: true
+    }
+  );
+});
+


### PR DESCRIPTION
## Summary

Implements Slack notifications for labeling decisions as specified in issue #51.

## Implementation

- **New Agent**:  - Self-contained Slack notification agent
- **Minimal Configuration**: Only 2 required properties (`SLACK_WEBHOOK_URL` + `SLACK_ENABLED`)
- **Label Filtering**: Configurable via `SLACK_LABELS` JSON array property
- **Rich Formatting**: Slack messages include email details, subject, sender, Gmail link, and color coding
- **Error Handling**: Graceful error handling - failures don't break email processing
- **Documentation**: Complete configuration guide and agent documentation

## Features

- ✅ Real-time notifications when labels are applied
- ✅ Configurable label filtering (notify for all or specific labels)
- ✅ Rich Slack message formatting with attachments
- ✅ Color-coded by label type (reply_needed=red, todo=yellow, review/summarize=green)
- ✅ Respects dry-run mode for safe testing
- ✅ Debug mode for detailed logging

## Configuration Examples

**Minimal setup** (notify for all labels):
```
SLACK_WEBHOOK_URL = https://hooks.slack.com/services/YOUR/WEBHOOK/URL
SLACK_ENABLED = true
```

**Selective notifications**:
```
SLACK_WEBHOOK_URL = https://hooks.slack.com/services/YOUR/WEBHOOK/URL
SLACK_ENABLED = true
SLACK_LABELS = ["reply_needed","todo"]
```

## Architecture

Follows existing patterns:
- Self-contained agent pattern (ADR-011)
- onLabel hook architecture (ADR-018)
- Similar to Todo Forwarder Agent implementation pattern

## Testing

- [x] Code follows existing patterns
- [x] Configuration documentation added
- [x] Agent documentation created
- [x] README updated
- [ ] Manual testing with actual Slack webhook (pending)

Closes #51