### PR TITLE
fix: respect SUMMARIZER_ARCHIVE_ON_LABEL and prevent re-classification loops

### DIFF
--- a/src/AgentSummarizer.gs
+++ b/src/AgentSummarizer.gs
@@ -493,7 +493,7 @@ function processEmailsAfterSummary_(emails, labelName) {
     let archiveResult = { success: true, archived: 0 };
     const shouldArchive = isCustomLabel
       ? config.CUSTOM_SUMMARIZER_ARCHIVE_ON_LABEL
-      : true; // Default 'summarize' label always archives
+      : config.SUMMARIZER_ARCHIVE_ON_LABEL; // Respect configuration (Issue #54)
 
     if (shouldArchive) {
       archiveResult = archiveEmailsByIds_(emailIds);

--- a/src/GmailService.gs
+++ b/src/GmailService.gs
@@ -1,5 +1,5 @@
 function findUnprocessed_(max) {
-  const q = 'in:inbox -label:reply_needed -label:review -label:todo -label:summarize';
+  const q = 'in:inbox -label:reply_needed -label:review -label:todo -label:summarize -label:summarized';
   return GmailApp.search(q, 0, max);
 }
 


### PR DESCRIPTION
## Summary

Fixes #54 - The `SUMMARIZER_ARCHIVE_ON_LABEL` configuration was being ignored by the nightly summarization workflow, causing all emails to be archived regardless of the setting.

## Changes

### Primary Fix: Respect Archive Configuration
- **File:** `src/AgentSummarizer.gs` (line 496)
- **Before:** `const shouldArchive = isCustomLabel ? config.CUSTOM_SUMMARIZER_ARCHIVE_ON_LABEL : true;`
- **After:** `const shouldArchive = isCustomLabel ? config.CUSTOM_SUMMARIZER_ARCHIVE_ON_LABEL : config.SUMMARIZER_ARCHIVE_ON_LABEL;`
- **Impact:** The nightly summarizer now respects the `SUMMARIZER_ARCHIVE_ON_LABEL` setting for default `summarize` label emails

### Prevention Fix: Avoid Re-classification Loops
- **File:** `src/GmailService.gs` (line 2)
- **Before:** `'in:inbox -label:reply_needed -label:review -label:todo -label:summarize'`
- **After:** `'in:inbox -label:reply_needed -label:review -label:todo -label:summarize -label:summarized'`
- **Impact:** Prevents emails with `summarized` label from being re-classified during hourly runs

## Testing

✅ Tested successfully on both work and personal Google accounts
- Verified emails with `summarize` label are processed correctly
- Verified `SUMMARIZER_ARCHIVE_ON_LABEL=false` keeps emails in inbox after summarization
- Verified `SUMMARIZER_ARCHIVE_ON_LABEL=true` archives emails after summarization
- Verified `summarized` emails are excluded from hourly classification

## Context

The bug had two execution paths:
1. **Hourly (onLabel hook):** When email is first labeled `summarize` - correctly respected config ✓
2. **Nightly (scheduled run):** When summary is generated at 5 AM - incorrectly ignored config ✗

This PR fixes the nightly workflow and adds safeguards against re-classification loops.