### PR TITLE
fix: Handle empty knowledge folders gracefully

### DIFF
--- a/src/AgentTemplate.gs
+++ b/src/AgentTemplate.gs
@@ -315,7 +315,7 @@ function fetchTemplateAgentKnowledge_(config) {
       maxDocs: maxDocs
     });
 
-    if (knowledgeResult.configured) {
+    if (knowledgeResult.configured && knowledgeResult.knowledge) {
       parts.push(knowledgeResult.knowledge);
       sources.push(...knowledgeResult.metadata.sources);
       totalChars += knowledgeResult.metadata.totalChars;

--- a/src/KnowledgeService.gs
+++ b/src/KnowledgeService.gs
@@ -459,12 +459,27 @@ function fetchFolder_(folderIdOrUrl, options) {
     }
   }
 
+  // Empty folder is not an error - just return empty knowledge
   if (docCount === 0) {
-    throw new Error(
-      'No accessible documents found in knowledge folder (ID: ' + folderId + ').\n' +
-      'Folder may be empty or you may lack permission to read documents.\n' +
-      'Configuration property: ' + (options.propertyName || 'unknown')
+    Logger.log(
+      'Knowledge folder is empty or contains no Google Docs (ID: ' + folderId + ').\n' +
+      'Configuration property: ' + (options.propertyName || 'unknown') + '\n' +
+      'Continuing without knowledge from this folder.'
     );
+    
+    return {
+      configured: true,
+      knowledge: null,
+      metadata: {
+        docCount: 0,
+        totalChars: 0,
+        estimatedTokens: 0,
+        modelLimit: 1048576,
+        utilizationPercent: '0.0%',
+        sources: [],
+        warning: 'Folder configured but empty or contains no accessible Google Docs'
+      }
+    };
   }
 
   const combinedKnowledge = knowledgeParts.join('\n');
@@ -579,7 +594,7 @@ function fetchLabelingKnowledge_(config) {
       maxDocs: maxDocs
     });
 
-    if (folderResult.configured) {
+    if (folderResult.configured && folderResult.knowledge) {
       parts.push(folderResult.knowledge);
       sources.push(...folderResult.metadata.sources);
       totalChars += folderResult.metadata.totalChars;
@@ -699,7 +714,7 @@ function fetchReplyKnowledge_(config) {
       maxDocs: maxDocs
     });
 
-    if (knowledgeResult.configured) {
+    if (knowledgeResult.configured && knowledgeResult.knowledge) {
       parts.push(knowledgeResult.knowledge);
       sources.push(...knowledgeResult.metadata.sources);
       totalChars += knowledgeResult.metadata.totalChars;
@@ -819,7 +834,7 @@ function fetchSummarizerKnowledge_(config) {
       maxDocs: maxDocs
     });
 
-    if (knowledgeResult.configured) {
+    if (knowledgeResult.configured && knowledgeResult.knowledge) {
       parts.push(knowledgeResult.knowledge);
       sources.push(...knowledgeResult.metadata.sources);
       totalChars += knowledgeResult.metadata.totalChars;


### PR DESCRIPTION
Previously, configuring a knowledge folder that was empty or contained no Google Docs would cause a fatal error. This prevented the system from running even when the folder configuration was optional.

Changes:
- Return empty knowledge result instead of throwing error when folder is empty
- Add warning metadata when folder configured but empty
- Add null checks before pushing knowledge to parts arrays
- Log informational message instead of failing

This allows users to:
- Configure folders in advance before adding documents
- Have optional/conditional knowledge folders
- Continue processing even if a knowledge folder is temporarily empty

Fixes issue where empty LABEL_KNOWLEDGE_FOLDER_URL caused runtime error.

_This fix was entirely vibe coded. Including everything above this line. Thanks, Claude. But I, Matthew, tested it._