### PR TITLE
feat: Add configurable label names via Script Properties

### DIFF
--- a/src/AgentReplyDrafter.gs
+++ b/src/AgentReplyDrafter.gs
@@ -448,8 +448,9 @@ function replyDrafterPostLabelScan_() {
       Logger.log('Reply Drafter postLabel: Starting inbox scan');
     }
 
-    // Find all emails with "reply_needed" label in inbox
-    const query = 'in:inbox label:reply_needed';
+    // Find all emails with reply_needed label in inbox
+    const coreConfig = getConfig_();
+    const query = `in:inbox label:"${coreConfig.LABEL_REPLY_NEEDED}"`;
     const threads = GmailApp.search(query);
 
     if (threads.length === 0) {
@@ -589,8 +590,9 @@ AGENT_MODULES.push(function(api) {
    * - onLabel: Immediate draft creation during classification
    * - postLabel: Inbox scan to catch manually-labeled emails
    */
+  const coreConfig = getConfig_();
   api.register(
-    'reply_needed',           // Label to trigger on
+    coreConfig.LABEL_REPLY_NEEDED,  // Label to trigger on
     'ReplyDrafter',           // Agent name
     {
       onLabel: processReplyNeeded_,      // Immediate per-email handler

--- a/src/Categorizer.gs
+++ b/src/Categorizer.gs
@@ -1,5 +1,5 @@
 function categorizeWithGemini_(emails, knowledge, cfg, globalKnowledge) {
-  const allowed = new Set(['reply_needed','review','todo','summarize']);
+  const allowed = new Set([cfg.LABEL_REPLY_NEEDED, cfg.LABEL_REVIEW, cfg.LABEL_TODO, cfg.LABEL_SUMMARIZE]);
   const batches = [];
   for (let i = 0; i < emails.length; i += cfg.BATCH_SIZE) {
     batches.push(emails.slice(i, i + cfg.BATCH_SIZE));
@@ -9,7 +9,7 @@ function categorizeWithGemini_(emails, knowledge, cfg, globalKnowledge) {
   for (const batch of batches) {
     // Build prompt using PromptBuilder (enforces separation of concerns)
     const prompt = buildCategorizePrompt_(batch, knowledge,
-      ['reply_needed', 'review', 'todo', 'summarize'],
+      [cfg.LABEL_REPLY_NEEDED, cfg.LABEL_REVIEW, cfg.LABEL_TODO, cfg.LABEL_SUMMARIZE],
       cfg.DEFAULT_FALLBACK_LABEL, globalKnowledge);
 
     // LLMService now receives complete prompt (no longer builds it internally)

--- a/src/Config.gs
+++ b/src/Config.gs
@@ -6,6 +6,11 @@ function getConfig_() {
     LOCATION: p.getProperty('GOOGLE_CLOUD_LOCATION') || 'us-central1',
     RULE_DOC_ID: p.getProperty('RULE_DOC_ID'),
     RULE_DOC_URL: p.getProperty('RULE_DOC_URL'),
+    // Label names (configurable)
+    LABEL_REPLY_NEEDED: p.getProperty('LABEL_REPLY_NEEDED') || 'reply_needed',
+    LABEL_REVIEW: p.getProperty('LABEL_REVIEW') || 'review',
+    LABEL_TODO: p.getProperty('LABEL_TODO') || 'todo',
+    LABEL_SUMMARIZE: p.getProperty('LABEL_SUMMARIZE') || 'summarize',
     DEFAULT_FALLBACK_LABEL: p.getProperty('DEFAULT_FALLBACK_LABEL') || 'review',
     MAX_EMAILS_PER_RUN: parseInt(p.getProperty('MAX_EMAILS_PER_RUN') || '10', 10),
     BATCH_SIZE: parseInt(p.getProperty('BATCH_SIZE') || '10', 10),
@@ -45,7 +50,8 @@ function getConfig_() {
 }
 
 function ensureLabels_() {
-  ['reply_needed','review','todo','summarize'].forEach(function(name) {
+  const cfg = getConfig_();
+  [cfg.LABEL_REPLY_NEEDED, cfg.LABEL_REVIEW, cfg.LABEL_TODO, cfg.LABEL_SUMMARIZE].forEach(function(name) {
     if (!GmailApp.getUserLabelByName(name)) GmailApp.createLabel(name);
   });
 }

--- a/src/Organizer.gs
+++ b/src/Organizer.gs
@@ -1,5 +1,6 @@
 function applyLabel_(thread, labelName, dryRun) {
-  const actionNames = ['reply_needed','review','todo','summarize'];
+  const cfg = getConfig_();
+  const actionNames = [cfg.LABEL_REPLY_NEEDED, cfg.LABEL_REVIEW, cfg.LABEL_TODO, cfg.LABEL_SUMMARIZE];
   const hasAny = thread.getLabels().some(function(l) { return actionNames.includes(l.getName()); });
   if (hasAny) return 'skipped';
   if (dryRun) return 'would-label:' + labelName;


### PR DESCRIPTION
Allow users to customize Gmail label names through Script Properties instead of hardcoded values. This enables use cases like emoji labels or organization-specific naming conventions.

Changes:
- Add LABEL_REPLY_NEEDED, LABEL_REVIEW, LABEL_TODO, LABEL_SUMMARIZE config properties with sensible defaults
- Update Config.gs to read label names from Script Properties
- Update all code files to use config properties instead of hardcoded strings (Categorizer, Organizer, and all Agent files)
- Maintain backward compatibility with default label names

Example usage:
  LABEL_REPLY_NEEDED = '↩️ Reply Needed' LABEL_REVIEW = '🕵🏼 Review' LABEL_TODO = '💥 Todo' LABEL_SUMMARIZE = '📚 Summarize'

This allows labels with emoji to sort before other labels and be more visually distinctive in the Gmail UI.

_This fix was entirely vibe coded. Including everything above this line. Thanks, Claude. But I, Matthew, tested it._